### PR TITLE
Check that logrus context is not nil

### DIFF
--- a/hook.go
+++ b/hook.go
@@ -80,9 +80,12 @@ func (hook Hook) Fire(entry *logrus.Entry) error {
 		event.Tags[k] = v
 	}
 
-	hub := sentry.GetHubFromContext(entry.Context)
-	if hub == nil {
-		hub = hook.hub
+	hub := hook.hub
+	if entry.Context != nil {
+		h := sentry.GetHubFromContext(entry.Context)
+		if h != nil {
+			hub = h
+		}
 	}
 
 	hook.converter(entry, event, hub)


### PR DESCRIPTION
I had a nil pointer crash with the hook if the log entry's context was nil. This fixes that by only using `sentry.GetHubFromContext` if the context is not nil.