### PR TITLE
support linking sentry errors to `opentelemetry` transactions

### DIFF
--- a/hook.go
+++ b/hook.go
@@ -89,7 +89,15 @@ func (hook Hook) Fire(entry *logrus.Entry) error {
 	}
 
 	hook.converter(entry, event, hub)
-	hub.CaptureEvent(event)
+
+	// hub.CaptureEvent does not support passing sentry.EventHint.
+	// See: https://docs.sentry.io/platforms/go/performance/instrumentation/opentelemetry/#linking-errors-to-transactions.
+	client, scope := hub.Client(), hub.Scope()
+	client.CaptureEvent(
+		event,
+		&sentry.EventHint{Context: entry.Context},
+		scope,
+	)
 
 	return nil
 }


### PR DESCRIPTION
Thank you for the great library! Recently I've transitioned an application to using 
Sentry + OpenTelemetry and the Sentry documentation indicates that the `Capture*` methods 
do not link errors, messages, or events to traces. This PR should fix that.

- see: https://docs.sentry.io/platforms/go/performance/instrumentation/opentelemetry/#linking-errors-to-transactions
